### PR TITLE
comment out funding plan tab to prevent error

### DIFF
--- a/app/views/activity_line_items/_details.html.haml
+++ b/app/views/activity_line_items/_details.html.haml
@@ -3,10 +3,10 @@
     %a{:href => "#asst", :data =>{:toggle => 'tab'}}
       %span.badge.pull-right= @activity_line_item.assets.count
       = "Assets"
-  %li
-    %a{:href => "#fund", :data =>{:toggle => 'tab'}}
-      %span.badge.pull-right= @activity_line_item.funding_plans.count
-      = "Funding Plans"
+  //%li
+  //  %a{:href => "#fund", :data =>{:toggle => 'tab'}}
+  //    %span.badge.pull-right= @activity_line_item.funding_plans.count
+  //    = "Funding Plans"
   %li
     %a{:href => "#mile", :data =>{:toggle => 'tab'}}
       %span.badge.pull-right= @activity_line_item.milestones.count
@@ -20,9 +20,9 @@
   .tab-pane.fade#asst
     .tab-content
       = render 'assets'
-  .tab-pane.fade#fund
-    .tab-content
-      = render 'funding_plans'
+  //.tab-pane.fade#fund
+  //  .tab-content
+  //    = render 'funding_plans'
   .tab-pane.fade#mile
     .tab-content
       = render 'milestones'


### PR DESCRIPTION
commented out reference to the funding plan tab on the activity line item detail view.  It was causing an error when the activity line item was selected