### PR TITLE
Make the rails version in the gemspec more restrictive

### DIFF
--- a/transam_cpt.gemspec
+++ b/transam_cpt.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 4.0.9"
+  s.add_dependency "rails", "~> 4.1.9"
   s.add_dependency 'jquery-ui-rails', '~> 4.2.1'
   s.add_dependency "wicked"
 


### PR DESCRIPTION
Part of a group of changes, addressing the problem that TransAM Engine dependencies were breaking bundler. Pull them in this order so that travis can confirm the changes work:

* spatial
* audit
* lib
* sign
* accounting
* cpt
* funding
